### PR TITLE
Correct typos; change collaborate to contribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Credit for this goes to [Jonah Duckles](https://github.com/jduckles)
 
 This repository serves as the base repository for use in a Software Carpentry Workshop 
-to show an example workflow for  collaborating on a project. The lesson plan is under
+to show an example workflow for contributing to a project. The lesson plan is under
 development and will be linked when complete. 
 
 
 #### Use
 
 Import, **do not fork**, this repository to your host account on GitHub. Use the import
-untilty provided by GitHub at [https://import.github.com](https://import.github.com)
+utilty provided by GitHub at [https://import.github.com](https://import.github.com)
 
 #### Disclaimer
 


### PR DESCRIPTION
Edit from collaborate to contribute because this is the correct terminology per GitHub. Collaborators have read/write access to the repo. Contributors make changes to the project via PRs.