### PR TITLE
Update readme.md with GitHub import link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ development and will be linked when complete.
 #### Use
 
 Import, **do not fork**, this repository to your host account on GitHub. Use the import
-utilty provided by GitHub at [https://import.github.com](https://import.github.com)
+utilty provided by GitHub at [https://github.com/new/import](https://github.com/new/import)
 
 #### Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ to show an example workflow for  collaborating on a project. The lesson plan is 
 development and will be linked when complete. 
 
 
-####Use
+#### Use
 
 Import, **do not fork**, this repository to your host account on GitHub. Use the import
 utilty provided by GitHub at [https://github.com/new/import](https://github.com/new/import)
 
 
-####Disclaimer
+#### Disclaimer
 
 This is a work in progress
 


### PR DESCRIPTION
The existing URL, import.github.com, resulted in a browser security error. Revised to new GitHub import link, which does not generate a browser security error.